### PR TITLE
Add support for form field lookup using key paths

### DIFF
--- a/library/headers/IBAForms/IBAFormDataSource.h
+++ b/library/headers/IBAForms/IBAFormDataSource.h
@@ -46,5 +46,6 @@
 - (IBAFormField *)formFieldAfter:(IBAFormField *)field;
 - (IBAFormField *)formFieldBefore:(IBAFormField *)field;
 - (NSIndexPath *)indexPathForFormField:(IBAFormField *)formField;
+- (NSArray *)formFieldForKeyPath:(NSString *)keyPath;
 
 @end

--- a/library/headers/IBAForms/IBAFormDataSource.h
+++ b/library/headers/IBAForms/IBAFormDataSource.h
@@ -46,6 +46,6 @@
 - (IBAFormField *)formFieldAfter:(IBAFormField *)field;
 - (IBAFormField *)formFieldBefore:(IBAFormField *)field;
 - (NSIndexPath *)indexPathForFormField:(IBAFormField *)formField;
-- (NSArray *)formFieldForKeyPath:(NSString *)keyPath;
+- (NSArray *)formFieldsForKeyPath:(NSString *)keyPath;
 
 @end

--- a/library/src/forms/controllers/IBAFormDataSource.m
+++ b/library/src/forms/controllers/IBAFormDataSource.m
@@ -90,7 +90,7 @@
 	return indexPath;
 }
 
-- (NSArray *)formFieldForKeyPath:(NSString *)keyPath {
+- (NSArray *)formFieldsForKeyPath:(NSString *)keyPath {
     NSMutableArray *fields = [[NSMutableArray alloc] init];
     
     NSUInteger sectionCount = [self sectionCount];

--- a/library/src/forms/controllers/IBAFormDataSource.m
+++ b/library/src/forms/controllers/IBAFormDataSource.m
@@ -90,6 +90,22 @@
 	return indexPath;
 }
 
+- (NSArray *)formFieldForKeyPath:(NSString *)keyPath {
+    NSMutableArray *fields = [[NSMutableArray alloc] init];
+    
+    NSUInteger sectionCount = [self sectionCount];
+    for (NSUInteger sectionIndex = 0; sectionIndex < sectionCount; sectionIndex++) {
+        NSUInteger fieldCount = [self numberOfFormFieldsInSection:sectionIndex];
+        for (NSUInteger fieldIndex = 0; fieldIndex < fieldCount; fieldIndex++) {
+            IBAFormField *formField = [self formFieldAtIndexPath:[NSIndexPath indexPathForRow:fieldIndex inSection:sectionIndex]];
+            if ([formField.keyPath isEqualToString:keyPath]) {
+                [fields addObject:formField];
+            }
+        }
+	}
+    
+    return fields;
+}
 
 // This method returns the next logical form field after the one provided. That may be the first field in the next 
 // section if the given field is the last in its section.


### PR DESCRIPTION
Given an IBAFormDataSource data_source, and a valid key path key_path which is mapped to one or more IBAFormField item(s), provide IBAFormField item(s).
